### PR TITLE
Add support for roku platform via user specified remote_entity or by defaulting to remote.{{entity_id}}

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | type | string | **Required** | `custom:tv-card`
 | entity | string | **Required** | The `media_player` entity to control.
 | platform | string | **Optional** | Platform of `media_player`. Supported values: `samsungtv`, `androidtv`, `webostv`, `roku`. If empty, it will use the keycodes for `samsungtv`.
-| remote_entity | string | **Required*** | The remote entity that controls the Roku `media_player`. Required only for `platform` type `roku`.
+| remote_entity | string | **Optional** | The remote entity that controls the Roku `media_player`. Defaults to `remote.{{entity_id}}`.
 | volume_entity | string | **Optional** | The `media_player` entity for volume control (working only with volume_row: `slider`). Defaults to the same in `entity`.
 | title | string | **Optional** | Card title for showing as header.
 | enable_double_click | boolean | **Optional** | Whether a double click on the touchpad should send the key in `double_click_keycode`. Defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@
 
 ## Options
 
-| Name | Type | Requirement | Description
-| ---- | ---- | ------- | -----------
-| type | string | **Required** | `custom:tv-card`
-| entity | string | **Required** | The `media_player` entity to control.
-| platform | string | **Optional** | Platform of `media_player`. Supported values: `samsungtv`, `androidtv`, `webostv`, `roku`. If empty, it will use the keycodes for `samsungtv`.
-| remote_entity | string | **Optional** | The remote entity that controls the Roku `media_player`. Defaults to `remote.{{entity_id}}`.
-| volume_entity | string | **Optional** | The `media_player` entity for volume control (working only with volume_row: `slider`). Defaults to the same in `entity`.
-| title | string | **Optional** | Card title for showing as header.
-| enable_double_click | boolean | **Optional** | Whether a double click on the touchpad should send the key in `double_click_keycode`. Defaults to `true`.
-| double_click_keycode | string | **Optional** | The key for double clicks on the touchpad. Defaults to `KEY_RETURN`
-| enable_button_feedback | boolean | **Optional** | Shall clicks on the buttons return a vibration feedback? Defaults to `true`.
-| enable_slider_feedback | boolean | **Optional** | Shall the volume slider return a vibration feedback when you slide through it? Defaults to `true`.
-| slider_config | object | **Optional** | Custom configuration for the volume slider. See [slider-card](https://github.com/AnthonMS/my-cards)
-| custom_keys | object | **Optional** | Custom keys for the remote control. Each item is an object that should have `icon` and at least one of the following properties: `key`, `source`, `service`.
-| custom_sources | object | **Optional** | Custom sources for the remote control. Same object as above, but letting you split keys and sources.
+| Name | Type | Requirement | Default |Description
+| ---- | ---- | ------- | ---- | -----------
+| type | string | **Required** | | `custom:tv-card`
+| entity | string | **Required** | | The `media_player` entity to control.
+| platform | string | **Optional** | `samsungtv` | Platform of `media_player`. Supported values: `samsungtv`, `androidtv`, `webostv`, `roku`
+| remote_entity | string | **Optional** | `remote.{{entity_id}}` | The remote entity that controls the Roku `media_player`
+| volume_entity | string | **Optional** | `entity` | The `media_player` entity for volume control (working only with volume_row: `slider`)
+| title | string | **Optional** | | Card title for showing as header.
+| enable_double_click | boolean | **Optional** | `true` | Whether a double click on the touchpad should send the key in `double_click_keycode`
+| double_click_keycode | string | **Optional** | `KEY_RETURN` | The key for double clicks on the touchpad. Defaults to `KEY_RETURN`
+| enable_button_feedback | boolean | **Optional** | `true` | Shall clicks on the buttons return a vibration feedback?
+| enable_slider_feedback | boolean | **Optional** | `true` | Shall the volume slider return a vibration feedback when you slide through it?
+| slider_config | object | **Optional** | | Custom configuration for the volume slider. See [slider-card](https://github.com/AnthonMS/my-cards)
+| custom_keys | object | **Optional** | | Custom keys for the remote control. Each item is an object that should have `icon` and at least one of the following properties: `key`, `source`, `service`.
+| custom_sources | object | **Optional** | | Custom sources for the remote control. Same object as above, but letting you split keys and sources.
 
 Using only these options you will get an empty card (or almost empty, if you set a title).
 In order to include the buttons, you need to specify in the config the rows you want and which buttons you want in it.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@
 | Name | Type | Requirement | Description
 | ---- | ---- | ------- | -----------
 | type | string | **Required** | `custom:tv-card`
-| entity | string | **Required** | The `media_player` entity to control
-| platform | string | **Optional** | Platform of `media_player`. Supported values: `androidtv`, `webostv`. If empty, it will use the keycodes for `samsungtv`
-| volume_entity | string | **Optional** | The `media_player` entity for volume control (working only with volume_row: `slider`). Defaults to the same in `entity`
-| title | string | **Optional** | Card title for showing as header
+| entity | string | **Required** | The `media_player` entity to control.
+| platform | string | **Optional** | Platform of `media_player`. Supported values: `samsungtv`, `androidtv`, `webostv`, `roku`. If empty, it will use the keycodes for `samsungtv`.
+| remote_entity | string | **Required*** | The remote entity that controls the Roku `media_player`. Required only for `platform` type `roku`.
+| volume_entity | string | **Optional** | The `media_player` entity for volume control (working only with volume_row: `slider`). Defaults to the same in `entity`.
+| title | string | **Optional** | Card title for showing as header.
 | enable_double_click | boolean | **Optional** | Whether a double click on the touchpad should send the key in `double_click_keycode`. Defaults to `true`.
 | double_click_keycode | string | **Optional** | The key for double clicks on the touchpad. Defaults to `KEY_RETURN`
 | enable_button_feedback | boolean | **Optional** | Shall clicks on the buttons return a vibration feedback? Defaults to `true`.

--- a/tv-card.js
+++ b/tv-card.js
@@ -103,11 +103,7 @@ class TVCardServices extends LitElement {
                 break;
             }
             case "roku": {
-                if (!config.remote_entity) {
-                    console.log("Invalid configuration. Must specify a remote_entity for platform type 'roku'.");
-                    return;
-                }
-                let remote_entity = config.remote_entity;
+                let remote_entity = !config.remote_entity ? "remote." + config.entity.split(".")[1] : config.remote_entity;
                 this.keys = {
                     "power": {"icon": "mdi:power", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "power"}},
                     "volume_up": {"icon": "mdi:volume-plus", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "volume_up"}},

--- a/tv-card.js
+++ b/tv-card.js
@@ -57,71 +57,102 @@ class TVCardServices extends LitElement {
             return;
         }
         this._config = { theme: "default", ...config };
-
-        if (config.platform === "androidtv" ) {
-            this.keys = {
-                "power": {"key": "POWER", "icon": "mdi:power"},
-                "volume_up": {"key": "VOLUME_UP", "icon": "mdi:volume-plus"},
-                "volume_down": {"key": "VOLUME_DOWN", "icon": "mdi:volume-minus"},
-                "volume_mute": {"key": "MUTE", "icon": "mdi:volume-mute"},
-                "return": {"key": "BACK", "icon": "mdi:arrow-left"},
-                "home": {"key": "HOME", "icon": "mdi:home"},
-                "up": {"key": "UP", "icon": "mdi:chevron-up"},
-                "left": {"key": "LEFT", "icon": "mdi:chevron-left"},
-                "enter": {"key": "CENTER", "icon": "mdi:checkbox-blank-circle"},
-                "right": {"key": "RIGHT", "icon": "mdi:chevron-right"},
-                "down": {"key": "DOWN", "icon": "mdi:chevron-down"},
-                "rewind": {"key": "REWIND", "icon": "mdi:rewind"},
-                "play": {"key": "RESUME", "icon": "mdi:play"},
-                "fast_forward": {"key": "FAST_FORWARD", "icon": "mdi:fast-forward"},
-                "menu": {"key": "MENU", "icon": "mdi:menu"},
-                "settings": {"key": "SETTINGS", "icon": "mdi:cog"},
-            };
-        }
-        else if (config.platform === "webostv" ) {
-            this.keys = {
-                "volume_up": {"key": "VOLUMEUP", "icon": "mdi:volume-plus"},
-                "volume_down": {"key": "VOLUMEDOWN", "icon": "mdi:volume-minus"},
-                "volume_mute": {"key": "MUTE", "icon": "mdi:volume-mute"},
-                "return": {"key": "BACK", "icon": "mdi:arrow-left"},
-                "info": {"key": "INFO", "icon": "mdi:information"},
-                "home": {"key": "HOME", "icon": "mdi:home"},
-                "channel_up": {"key": "CHANNELUP", "icon": "mdi:arrow-up"},
-                "channel_down": {"key": "CHANNELDOWN", "icon": "mdi:arrow-down"},
-                "up": {"key": "UP", "icon": "mdi:chevron-up"},
-                "left": {"key": "LEFT", "icon": "mdi:chevron-left"},
-                "enter": {"key": "ENTER", "icon": "mdi:checkbox-blank-circle"},
-                "right": {"key": "RIGHT", "icon": "mdi:chevron-right"},
-                "down": {"key": "DOWN", "icon": "mdi:chevron-down"},
-                "play": {"key": "PLAY", "icon": "mdi:play"},
-                "pause": {"key": "PAUSE", "icon": "mdi:pause"},
-                "menu": {"key": "MENU", "icon": "mdi:menu"},
-                "guide": {"key": "GUIDE", "icon": "mdi:television-guide"},
-                "exit": {"key": "EXIT", "icon": "mdi:close"},
-            };
-        }
-        else {
-            this.keys = {
-                "power": {"key": "KEY_POWER", "icon": "mdi:power"},
-                "volume_up": {"key": "KEY_VOLUP", "icon": "mdi:volume-plus"},
-                "volume_down": {"key": "KEY_VOLDOWN", "icon": "mdi:volume-minus"},
-                "volume_mute": {"key": "KEY_MUTE", "icon": "mdi:volume-mute"},
-                "return": {"key": "KEY_RETURN", "icon": "mdi:arrow-left"},
-                "source": {"key": "KEY_SOURCE", "icon": "mdi:video-input-hdmi"},
-                "info": {"key": "KEY_INFO", "icon": "mdi:television-guide"},
-                "home": {"key": "KEY_HOME", "icon": "mdi:home"},
-                "channel_up": {"key": "KEY_CHUP", "icon": "mdi:arrow-up"},
-                "channel_down": {"key": "KEY_CHDOWN", "icon": "mdi:arrow-down"},
-                "up": {"key": "KEY_UP", "icon": "mdi:chevron-up"},
-                "left": {"key": "KEY_LEFT", "icon": "mdi:chevron-left"},
-                "enter": {"key": "KEY_ENTER", "icon": "mdi:checkbox-blank-circle"},
-                "right": {"key": "KEY_RIGHT", "icon": "mdi:chevron-right"},
-                "down": {"key": "KEY_DOWN", "icon": "mdi:chevron-down"},
-                "rewind": {"key": "KEY_REWIND", "icon": "mdi:rewind"},
-                "play": {"key": "KEY_PLAY", "icon": "mdi:play"},
-                "pause": {"key": "KEY_PAUSE", "icon": "mdi:pause"},
-                "fast_forward": {"key": "KEY_FF", "icon": "mdi:fast-forward"},
-            };
+        switch(config.platform) {
+            case "androidtv": {
+                this.keys = {
+                    "power": {"key": "POWER", "icon": "mdi:power"},
+                    "volume_up": {"key": "VOLUME_UP", "icon": "mdi:volume-plus"},
+                    "volume_down": {"key": "VOLUME_DOWN", "icon": "mdi:volume-minus"},
+                    "volume_mute": {"key": "MUTE", "icon": "mdi:volume-mute"},
+                    "return": {"key": "BACK", "icon": "mdi:arrow-left"},
+                    "home": {"key": "HOME", "icon": "mdi:home"},
+                    "up": {"key": "UP", "icon": "mdi:chevron-up"},
+                    "left": {"key": "LEFT", "icon": "mdi:chevron-left"},
+                    "enter": {"key": "CENTER", "icon": "mdi:checkbox-blank-circle"},
+                    "right": {"key": "RIGHT", "icon": "mdi:chevron-right"},
+                    "down": {"key": "DOWN", "icon": "mdi:chevron-down"},
+                    "rewind": {"key": "REWIND", "icon": "mdi:rewind"},
+                    "play": {"key": "RESUME", "icon": "mdi:play"},
+                    "fast_forward": {"key": "FAST_FORWARD", "icon": "mdi:fast-forward"},
+                    "menu": {"key": "MENU", "icon": "mdi:menu"},
+                    "settings": {"key": "SETTINGS", "icon": "mdi:cog"},
+                };
+                break;
+            }
+            case "webostv": {
+                this.keys = {
+                    "volume_up": {"key": "VOLUMEUP", "icon": "mdi:volume-plus"},
+                    "volume_down": {"key": "VOLUMEDOWN", "icon": "mdi:volume-minus"},
+                    "volume_mute": {"key": "MUTE", "icon": "mdi:volume-mute"},
+                    "return": {"key": "BACK", "icon": "mdi:arrow-left"},
+                    "info": {"key": "INFO", "icon": "mdi:information"},
+                    "home": {"key": "HOME", "icon": "mdi:home"},
+                    "channel_up": {"key": "CHANNELUP", "icon": "mdi:arrow-up"},
+                    "channel_down": {"key": "CHANNELDOWN", "icon": "mdi:arrow-down"},
+                    "up": {"key": "UP", "icon": "mdi:chevron-up"},
+                    "left": {"key": "LEFT", "icon": "mdi:chevron-left"},
+                    "enter": {"key": "ENTER", "icon": "mdi:checkbox-blank-circle"},
+                    "right": {"key": "RIGHT", "icon": "mdi:chevron-right"},
+                    "down": {"key": "DOWN", "icon": "mdi:chevron-down"},
+                    "play": {"key": "PLAY", "icon": "mdi:play"},
+                    "pause": {"key": "PAUSE", "icon": "mdi:pause"},
+                    "menu": {"key": "MENU", "icon": "mdi:menu"},
+                    "guide": {"key": "GUIDE", "icon": "mdi:television-guide"},
+                    "exit": {"key": "EXIT", "icon": "mdi:close"},
+                };
+                break;
+            }
+            case "roku": {
+                if (!config.remote_entity) {
+                    console.log("Invalid configuration. Must specify a remote_entity for platform type 'roku'.");
+                    return;
+                }
+                let remote_entity = config.remote_entity;
+                this.keys = {
+                    "power": {"icon": "mdi:power", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "power"}},
+                    "volume_up": {"icon": "mdi:volume-plus", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "volume_up"}},
+                    "volume_down": {"icon": "mdi:volume-minus", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "volume_down"}},
+                    "volume_mute": {"icon": "mdi:volume-mute", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "volume_mute"}},
+                    "return": {"icon": "mdi:arrow-left", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "back"}},
+                    "info": {"icon": "mdi:asterisk", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "info"}},
+                    "home": {"icon": "mdi:home", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "home"}},
+                    "channel_up": {"icon": "mdi:arrow-up", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "channel_up"}},
+                    "channel_down": {"icon": "mdi:arrow-down", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "channel_down"}},
+                    "up": {"icon": "mdi:chevron-up", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "up"}},
+                    "left": {"icon": "mdi:chevron-left", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "left"}},
+                    "enter": {"icon": "mdi:checkbox-blank-circle", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "select"}},
+                    "right": {"icon": "mdi:chevron-right", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "right"}},
+                    "down": {"icon": "mdi:chevron-down", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "down"}},
+                    "rewind": {"icon": "mdi:rewind", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "reverse"}},
+                    "play": {"icon": "mdi:play-pause", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "play"}},
+                    "fast_forward": {"icon": "mdi:fast-forward", "service": "remote.send_command", "service_data": { "entity_id": remote_entity, "command": "forward"}},
+                };
+                break;
+            }
+            case "samsungtv":
+            default: {
+                this.keys = {
+                    "power": {"key": "KEY_POWER", "icon": "mdi:power"},
+                    "volume_up": {"key": "KEY_VOLUP", "icon": "mdi:volume-plus"},
+                    "volume_down": {"key": "KEY_VOLDOWN", "icon": "mdi:volume-minus"},
+                    "volume_mute": {"key": "KEY_MUTE", "icon": "mdi:volume-mute"},
+                    "return": {"key": "KEY_RETURN", "icon": "mdi:arrow-left"},
+                    "source": {"key": "KEY_SOURCE", "icon": "mdi:video-input-hdmi"},
+                    "info": {"key": "KEY_INFO", "icon": "mdi:television-guide"},
+                    "home": {"key": "KEY_HOME", "icon": "mdi:home"},
+                    "channel_up": {"key": "KEY_CHUP", "icon": "mdi:arrow-up"},
+                    "channel_down": {"key": "KEY_CHDOWN", "icon": "mdi:arrow-down"},
+                    "up": {"key": "KEY_UP", "icon": "mdi:chevron-up"},
+                    "left": {"key": "KEY_LEFT", "icon": "mdi:chevron-left"},
+                    "enter": {"key": "KEY_ENTER", "icon": "mdi:checkbox-blank-circle"},
+                    "right": {"key": "KEY_RIGHT", "icon": "mdi:chevron-right"},
+                    "down": {"key": "KEY_DOWN", "icon": "mdi:chevron-down"},
+                    "rewind": {"key": "KEY_REWIND", "icon": "mdi:rewind"},
+                    "play": {"key": "KEY_PLAY", "icon": "mdi:play"},
+                    "pause": {"key": "KEY_PAUSE", "icon": "mdi:pause"},
+                    "fast_forward": {"key": "KEY_FF", "icon": "mdi:fast-forward"},
+                };
+            }
         }
 
         this.custom_keys = config.custom_keys || {};


### PR DESCRIPTION
Hi Cezar! I was playing around with the new platform support and was able to get it to work with Roku TVs. I also did a bit of refactoring (swapped the if-else to a more appealing switch statement), and added a defaults column to the readme. Let me know what are your thoughts!